### PR TITLE
frx: resolve an import by what declares the symbol, in every package

### DIFF
--- a/tools/lib/src/scaffold/type_imports.dart
+++ b/tools/lib/src/scaffold/type_imports.dart
@@ -23,10 +23,10 @@ import 'dart:io';
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
 
 import '../ast/source_index.dart';
 import '../redux/ast_edit.dart';
-import '../util/casing.dart';
 import '../workspace/frx_workspace.dart';
 
 /// Maps a type a caller can ask for to the import that supplies it.
@@ -114,142 +114,147 @@ abstract final class ProjectTypeImports {
   /// how the prune side got its own second answer to "what does this file
   /// hold", and the two disagreed.
   static List<String> forAll(FrxWorkspace repo, Iterable<String?> snippets) {
-    final models = repo.modelsLib;
-    if (!models.existsSync()) return const [];
-    final package = _packageName(models.parent);
-    if (package == null) return const [];
+    final packages = _ImportablePackages.of(repo);
+    if (packages.isEmpty) return const [];
 
     final memo = <String, String?>{};
     final found = <String>{};
     for (final snippet in snippets.nonNulls) {
       for (final match in _identifier.allMatches(snippet)) {
-        final file = _fileFor(models, match.group(1)!, memo);
-        if (file != null) found.add('package:$package/$file');
+        final uri = _uriFor(packages, match.group(1)!, memo);
+        if (uri != null) found.add(uri);
       }
     }
     return found.toList()..sort();
   }
 
-  /// What proves the import of model file [basename] is still needed by [body].
+  /// The import URI that supplies [identifier], or null when no package here
+  /// does — or when more than one does.
+  ///
+  /// **Ambiguity resolves to nothing.** Two packages can declare the same
+  /// `Clock`, and this module's safety argument is that it never produces a
+  /// *wrong* import: a missed one is a compile error naming the type, a wrong
+  /// one is a compile error naming something else, or worse, a silent bind to
+  /// the other package's class. So a name that resolves twice is treated as a
+  /// name that did not resolve, and the caller falls back to `--import`.
+  static String? _uriFor(
+    List<_ImportablePackage> packages,
+    String identifier,
+    Map<String, String?> memo,
+  ) => memo.putIfAbsent(identifier, () {
+    final hits = <String>{};
+    for (final package in packages) {
+      final uri = package.uriFor(identifier);
+      if (uri != null) hits.add(uri);
+    }
+    return hits.length == 1 ? hits.single : null;
+  });
+
+  /// What proves the import [uri] is still needed by [body].
   ///
   /// The same resolution read backwards: an identifier in [body] keeps the
-  /// import alive when it resolves to *that file*. Not "does `Result` still
+  /// import alive when it resolves to *that URI*. Not "does `Result` still
   /// appear" — a union's cases are supplied by the file its union names, so
   /// `ResultSuccess` alone keeps `result.dart`, and not "does anything starting
   /// with `Task` appear", which was the guess this replaces and which kept
   /// `task.dart` alive for a surviving `TaskList`.
-  static ImportProbe probeFor(FrxWorkspace repo, String basename) {
-    final models = repo.modelsLib;
+  ///
+  /// Keyed by the URI rather than the file basename it used to take: once more
+  /// than one package can supply an import, `digest.dart` no longer identifies
+  /// one, and two packages with a same-named file would have shared a probe.
+  static ImportProbe probeFor(FrxWorkspace repo, String uri) {
+    final packages = _ImportablePackages.of(repo);
     // One memo for the whole probe: a state file names dozens of identifiers
     // and most of them are not models at all, so a miss must be paid once.
     final memo = <String, String?>{};
     return (body) {
       for (final match in _identifier.allMatches(body)) {
-        if (_fileFor(models, match.group(1)!, memo) == basename) return true;
+        if (_uriFor(packages, match.group(1)!, memo) == uri) return true;
       }
       return false;
     };
   }
 
-  /// The model file basename that supplies [identifier], or null when this
-  /// project has none.
-  ///
-  /// Two questions, in cost order. **By name** — `Task` is in `task.dart` —
-  /// which is the convention `add-model` writes and costs one `existsSync`.
-  /// **By declaration**, when that misses: a file supplies more names than the
-  /// one it is called after, and the case that matters is the sealed union,
-  /// where `add-model Result -c success` writes
-  ///
-  /// ```dart
-  /// sealed class Result with _$Result {
-  ///   const factory Result.success() = ResultSuccess;
-  /// }
-  /// ```
-  ///
-  /// `ResultSuccess` is declared in the generated part and reached through
-  /// `result.dart`, so the name-based lookup asked for a `result_success.dart`
-  /// that does not exist and `add-field last:ResultSuccess?` wrote a field with
-  /// nothing importing its type. The redirect is the statement that ties the
-  /// two, and it is in the source file rather than the generated one — so this
-  /// answers before `build_runner` has ever run.
-  ///
-  /// [memo] holds both hits and misses: the second question reads the whole
-  /// models directory, and a snippet naming `String`, `IList` and `Default`
-  /// would otherwise pay for it once per word.
-  static String? _fileFor(
-    Directory models,
-    String identifier,
-    Map<String, String?> memo,
-  ) => memo.putIfAbsent(
-    identifier,
-    () => _byName(models, identifier) ?? _byDeclaration(models, identifier),
-  );
+}
 
-  static String? _byName(Directory models, String identifier) {
-    final String snake;
+/// The packages a file generated into `business` may name a type from.
+///
+/// `models` and no more was the whole answer until this: the resolver joined
+/// `<root>/models/lib/<snake>.dart` and stopped, so a type living in any other
+/// package of the workspace — or in a sibling checkout brought in by a path
+/// dependency — could not be resolved and `add-field` wrote a field whose type
+/// nothing imported. The gap was not "domain types are unknown", which is how
+/// it reads from outside: `models`-resident domain types resolved fine. It was
+/// that the search space was one directory.
+///
+/// The set is read from `business/pubspec.yaml` rather than the workspace list,
+/// because those are different sets and only one of them is the right one. A
+/// path dependency need not be a workspace member (a sibling checkout under
+/// active development is the case that matters), and a workspace member need
+/// not be a dependency — and what a generated file may import is exactly what
+/// its own package declares.
+abstract final class _ImportablePackages {
+  const _ImportablePackages._();
+
+  /// Every package `business` may import from, that this repository can read.
+  ///
+  /// `models` is included whether or not it is declared: the template's own
+  /// `business` depends on it, and a fixture that omits the dependency block
+  /// still has to resolve the models it writes.
+  static List<_ImportablePackage> of(FrxWorkspace repo) {
+    final dirs = <String, Directory>{};
+
+    final models = repo.modelsLib;
+    if (models.existsSync()) dirs[p.canonicalize(models.path)] = models;
+
+    final business = repo.businessLib.parent;
+    for (final dep in _pathDeps(business)) {
+      final lib = Directory(p.join(dep.path, 'lib'));
+      if (lib.existsSync()) dirs.putIfAbsent(p.canonicalize(lib.path), () => lib);
+    }
+
+    final packages = <_ImportablePackage>[];
+    for (final lib in dirs.values) {
+      final name = _packageName(lib.parent);
+      if (name != null) packages.add(_ImportablePackage(name, lib));
+    }
+    // Sorted so two packages that both resolve a name are detected as an
+    // ambiguity in the same order every run, rather than in listing order.
+    return packages..sort((a, b) => a.name.compareTo(b.name));
+  }
+
+  /// The directories of the `path:` dependencies declared in [dir]'s pubspec.
+  ///
+  /// Direct only, and deliberately: Dart lets a file import the packages its own
+  /// package declares and no others, so a transitive walk would resolve names to
+  /// imports that do not compile — the one failure mode this module promises not
+  /// to have.
+  static List<Directory> _pathDeps(Directory dir) {
+    final pubspec = File(p.join(dir.path, 'pubspec.yaml'));
+    if (!pubspec.existsSync()) return const [];
+    final Object? doc;
     try {
-      snake = Casing.parse(identifier).snake;
-    } on FormatException {
-      return null;
+      doc = loadYaml(pubspec.readAsStringSync());
+    } on YamlException {
+      // A pubspec frx cannot parse is the user's problem to fix, and not one
+      // worth failing `add-field` over: the resolution degrades to `models`.
+      return const [];
     }
-    return File(p.join(models.path, '$snake.dart')).existsSync()
-        ? '$snake.dart'
-        : null;
-  }
+    if (doc is! YamlMap) return const [];
 
-  /// The model file that declares [identifier] — or redirects a factory to it,
-  /// which is how a freezed union names its cases.
-  ///
-  /// Text first: [SourceIndex.unitIf] reads each file and parses only the ones
-  /// that contain the word at all, so a miss costs reads and no parses.
-  /// Generated files are not searched — `result.freezed.dart` declares the case
-  /// too, and importing *it* is not how anybody reaches the class.
-  static String? _byDeclaration(Directory models, String identifier) {
-    for (final file in sourceIndex.filesUnder(models, recursive: false)) {
-      final unit = sourceIndex.unitIf(file, (s) => s.contains(identifier));
-      if (unit == null) continue;
-      if (_declares(unit, identifier)) return p.basename(file.path);
-    }
-    return null;
-  }
-
-  static bool _declares(CompilationUnit unit, String identifier) {
-    for (final declaration in unit.declarations) {
-      // Each kind carries its own name, and the analyzer 14 spelling differs
-      // between them — `namePart.typeName` for the ones that can be augmented,
-      // a plain `name` for the rest. There is no shared supertype to ask, so
-      // the list is spelled out.
-      //
-      // A kind missing from it is **not** symmetric between the two directions
-      // this resolver serves. Adding: a missed import is a compile error naming
-      // the type, which is loud. Pruning: the probe reads "nothing here needs
-      // that file" and takes a live import out — silent, and in a state file
-      // nobody is allowed to put back by hand. So a new declaration kind
-      // belongs here before it belongs anywhere.
-      final declared = switch (declaration) {
-        ClassDeclaration(:final namePart) ||
-        ExtensionTypeDeclaration(:final namePart) ||
-        EnumDeclaration(:final namePart) => namePart.typeName.lexeme,
-        MixinDeclaration(:final name) || TypeAlias(:final name) => name.lexeme,
-        _ => null,
-      };
-      if (declared == identifier) return true;
-
-      // `const factory Result.success() = ResultSuccess;` — the case class is
-      // generated, and this is where the source says its name.
-      if (declaration is ClassDeclaration) {
-        final body = declaration.body;
-        final members = body is BlockClassBody
-            ? body.members
-            : const <ClassMember>[];
-        for (final member in members.whereType<ConstructorDeclaration>()) {
-          if (member.redirectedConstructor?.type.name.lexeme == identifier) {
-            return true;
-          }
+    final deps = <Directory>[];
+    for (final section in const ['dependencies', 'dependency_overrides']) {
+      final entries = doc[section];
+      if (entries is! YamlMap) continue;
+      for (final spec in entries.values) {
+        if (spec is! YamlMap) continue;
+        final path = spec['path'];
+        if (path is String) {
+          deps.add(Directory(p.normalize(p.join(dir.path, path))));
         }
       }
     }
-    return false;
+    return deps;
   }
 
   /// The `name:` of the pubspec in [dir], or null when there is none to read.
@@ -264,6 +269,248 @@ abstract final class ProjectTypeImports {
     ).firstMatch(pubspec.readAsStringSync());
     return match?.group(1);
   }
+}
+
+/// One package, asked "what would a file have to import to name this type?".
+class _ImportablePackage {
+  _ImportablePackage(this.name, this.lib);
+
+  final String name;
+  final Directory lib;
+
+  final _entries = <String, String?>{};
+
+  /// The import URI of this package that supplies [identifier], or null.
+  ///
+  /// Two questions. **Which file declares it**, and then **which entry point
+  /// exports that file**, when the declaration turns out to live under
+  /// `lib/src/` — private by pub's convention, and importing it directly is not
+  /// how anybody reaches the class.
+  ///
+  /// There used to be a third, asked first and cheapest: `Task` is in
+  /// `task.dart`, the convention `add-model` writes, one `existsSync`. It is
+  /// gone because it answered from the *file name* and never opened the file.
+  /// A `models/lib/task.dart` holding `class TaskList` and a `Task` next door in
+  /// `other.dart` made it answer `package:models/task.dart` for `Task` — an
+  /// import that resolves and does not supply the name, which is the one failure
+  /// this module's doc promises it cannot have. The convention it encoded is not
+  /// lost: when `task.dart` does declare `Task`, the declaration search finds it
+  /// there, having checked.
+  String? uriFor(String identifier) {
+    final file = _byDeclaration(identifier);
+    return file == null ? null : _entryFor(file, identifier, {});
+  }
+
+  /// The file that declares [identifier] — or redirects a factory to it, which
+  /// is how a freezed union names its cases.
+  ///
+  /// Text first: [SourceIndex.unitIf] reads each file and parses only the ones
+  /// that contain the word at all, so a miss costs reads and no parses. That
+  /// pre-filter is what makes the widened search space affordable — the six path
+  /// dependencies of one real app are 228 files and 1.3 MB, of which a given
+  /// identifier matches a handful.
+  ///
+  /// Recursive, unlike the `models`-only lookup this replaces: `lib/src/` is
+  /// where a package with a barrel keeps everything, and `models/lib/converters/`
+  /// was invisible to the old walk for the same reason.
+  ///
+  /// Generated files are not searched — `result.freezed.dart` declares the case
+  /// too, and importing *it* is not how anybody reaches the class.
+  File? _byDeclaration(String identifier) {
+    final wanted = _declarationText(identifier);
+    for (final file in sourceIndex.filesUnder(lib)) {
+      final unit = sourceIndex.unitIf(file, wanted.hasMatch);
+      if (unit == null) continue;
+      if (_declares(unit, identifier)) return file;
+    }
+    return null;
+  }
+
+  /// The text a file must contain before it is worth parsing for [identifier].
+  ///
+  /// A plain `contains` is not a pre-filter here, it is a full scan wearing one:
+  /// `String` occurs in essentially every Dart file, so `add-field x note:String?`
+  /// parsed all 161 files of one real app's dependency closure to conclude that
+  /// none of them declares it — 400 ms and 161 parses to answer "no". Matching
+  /// the *declaration* instead costs the same read and almost never the parse.
+  ///
+  /// Kept deliberately in step with [_declares], which is the authority: this
+  /// only has to be no *narrower*, and `type_imports` asserts exactly that over
+  /// every declaration form Dart has. A branch missing here is not a slow
+  /// answer, it is a wrong one — the file is never parsed, so the declaration
+  /// in it is never seen and the import never written.
+  ///
+  /// The branches, in the order they appear:
+  ///
+  /// - the keyword forms. `abstract final class X`, `sealed class X` and
+  ///   `mixin class X` all contain `class X`; `extension type const X(int i)`
+  ///   is why `const` is optional there.
+  /// - `typedef`, which has two syntaxes and puts the name in a different place
+  ///   in each — `typedef X = void Function()` and the legacy
+  ///   `typedef void X()`. Bounded to one statement so it cannot run away.
+  /// - the redirect a freezed union writes, `= ResultSuccess;`, which is how a
+  ///   case class is named in source before `build_runner` generates it.
+  static RegExp _declarationText(String identifier) {
+    final name = RegExp.escape(identifier);
+    return RegExp(
+      r'(?:class|mixin|enum|extension\s+type(?:\s+const)?)\s+' '$name' r'\b'
+      r'|typedef[^;\n]*\b' '$name' r'\b'
+      r'|=\s*' '$name' r'\s*[;(<]',
+    );
+  }
+
+  /// The importable URI for [file] — itself when it is public, otherwise the
+  /// entry point that exports it.
+  ///
+  /// Walked upwards from the declaration rather than downwards from every entry
+  /// point, because the two directions cost differently: a package's export
+  /// closure is its whole source tree (`tm_core` is 163 files), while the files
+  /// that mention one basename are a handful the text pre-filter finds. [seen]
+  /// bounds a cyclic re-export.
+  String? _entryFor(File file, String identifier, Set<String> seen) {
+    final key = p.canonicalize(file.path);
+    if (!seen.add(key)) return null;
+
+    final relative = p.url.joinAll(
+      p.split(p.relative(file.path, from: lib.path)),
+    );
+    if (!relative.startsWith('src/')) return 'package:$name/$relative';
+
+    // Keyed by the identifier as well as the file: `show`/`hide` mean two names
+    // declared side by side in one private file can come out of different entry
+    // points, or one of them out of none.
+    return _entries.putIfAbsent('$identifier|$key', () {
+      final basename = p.basename(file.path);
+      for (final candidate in sourceIndex.filesUnder(lib)) {
+        if (p.canonicalize(candidate.path) == key) continue;
+        final unit = sourceIndex.unitIf(candidate, (s) => s.contains(basename));
+        if (unit == null) continue;
+        if (!_exports(unit, candidate, key, identifier)) continue;
+        final uri = _entryFor(candidate, identifier, seen);
+        if (uri != null) return uri;
+      }
+      return null;
+    });
+  }
+
+  /// Whether [unit] re-exports [identifier] from the file at [target].
+  ///
+  /// Only relative exports are followed. `export 'package:other/other.dart'` is
+  /// a different package's entry point, and this package is not what supplies
+  /// the name — the other one is, and it is resolved on its own if it is a
+  /// dependency and correctly not resolved if it is not.
+  ///
+  /// The combinators are honoured, and that is not pedantry: this module's whole
+  /// safety argument is that it can miss an import but never invent a wrong one,
+  /// and `export 'src/store.dart' show SqliteEventStore` is a real barrel in a
+  /// real dependency here. Answering `package:tm_store_sqlite/tm_store_sqlite.dart`
+  /// for the *other* class in that file would be an import that resolves and
+  /// does not supply the name — the exact failure the doc above promises away.
+  static bool _exports(
+    CompilationUnit unit,
+    File from,
+    String target,
+    String identifier,
+  ) {
+    for (final directive in unit.directives.whereType<ExportDirective>()) {
+      final uri = directive.uri.stringValue;
+      if (uri == null || uri.contains(':')) continue;
+      final resolved = p.canonicalize(
+        p.normalize(p.join(p.dirname(from.path), p.fromUri(uri))),
+      );
+      if (resolved != target) continue;
+      if (_combinatorsAdmit(directive, identifier, File(target))) return true;
+    }
+    return false;
+  }
+
+  /// Whether [directive]'s `show`/`hide` list lets [identifier] out of [target].
+  ///
+  /// A union case is admitted by its union's name too — `show Result` exports
+  /// `ResultSuccess`, because the case is a constructor redirect on the class
+  /// the combinator names, not a separate top-level name to list. Established by
+  /// reading that redirect in [target], **not** by `ResultSuccess.startsWith`:
+  /// the prefix guess admits `MemoryDigestInternals` for a `show MemoryDigest`,
+  /// which is the same guess this module's `probeFor` doc records having thrown
+  /// out for keeping `task.dart` alive for a surviving `TaskList`.
+  static bool _combinatorsAdmit(
+    ExportDirective directive,
+    String identifier,
+    File target,
+  ) {
+    for (final combinator in directive.combinators) {
+      switch (combinator) {
+        case ShowCombinator(:final shownNames):
+          final shown = shownNames.map((n) => n.name).toSet();
+          if (shown.contains(identifier)) continue;
+          final unit = sourceIndex.unitIf(
+            target,
+            (s) => s.contains(identifier),
+          );
+          final owners = unit == null
+              ? const <String>{}
+              : _redirectOwners(unit, identifier);
+          if (owners.any(shown.contains)) continue;
+          return false;
+        case HideCombinator(:final hiddenNames):
+          if (hiddenNames.any((n) => n.name == identifier)) return false;
+      }
+    }
+    return true;
+  }
+
+  /// Whether [unit] supplies [identifier] — declares it outright, or names it as
+  /// the case of a union it declares.
+  static bool _declares(CompilationUnit unit, String identifier) =>
+      _declaredNames(unit).contains(identifier) ||
+      _redirectOwners(unit, identifier).isNotEmpty;
+
+  /// The top-level type names [unit] declares.
+  static Set<String> _declaredNames(CompilationUnit unit) => {
+    for (final declaration in unit.declarations)
+      // Each kind carries its own name, and the analyzer 14 spelling differs
+      // between them — `namePart.typeName` for the ones that can be augmented,
+      // a plain `name` for the rest. There is no shared supertype to ask, so
+      // the list is spelled out.
+      //
+      // A kind missing from it is **not** symmetric between the two directions
+      // this resolver serves. Adding: a missed import is a compile error naming
+      // the type, which is loud. Pruning: the probe reads "nothing here needs
+      // that file" and takes a live import out — silent, and in a state file
+      // nobody is allowed to put back by hand. So a new declaration kind
+      // belongs here before it belongs anywhere.
+      if (switch (declaration) {
+        ClassDeclaration(:final namePart) ||
+        ExtensionTypeDeclaration(:final namePart) ||
+        EnumDeclaration(:final namePart) => namePart.typeName.lexeme,
+        MixinDeclaration(:final name) || TypeAlias(:final name) => name.lexeme,
+        _ => null,
+      }
+      case final String declared)
+        declared,
+  };
+
+  /// The classes in [unit] that redirect a factory to [identifier] — the shape
+  /// `const factory Result.success() = ResultSuccess;` has, where the case class
+  /// itself is generated and this is where the source says its name.
+  ///
+  /// One reading of the redirect, asked two ways. "Does this file supply
+  /// `ResultSuccess`?" is `isNotEmpty`; "does `show Result` carry it?" is
+  /// `contains('Result')`. They were two functions walking the same members for
+  /// the same statement, which is how a resolver ends up agreeing with itself
+  /// only by coincidence.
+  static Set<String> _redirectOwners(CompilationUnit unit, String identifier) =>
+      {
+        for (final declaration
+            in unit.declarations.whereType<ClassDeclaration>())
+          if (switch (declaration.body) {
+            BlockClassBody(:final members) => members,
+            _ => const <ClassMember>[],
+          }.whereType<ConstructorDeclaration>().any(
+            (m) => m.redirectedConstructor?.type.name.lexeme == identifier,
+          ))
+            declaration.namePart.typeName.lexeme,
+      };
 }
 
 /// The imports a *removed* snippet may have been the last user of, each with
@@ -295,7 +542,7 @@ abstract final class ImportProbes {
     // happened to name are not the only ones it supplies, and the probe has to
     // answer for all of them.
     for (final uri in ProjectTypeImports.forAll(repo, snippets)) {
-      probes[uri] = ProjectTypeImports.probeFor(repo, p.basename(uri));
+      probes[uri] = ProjectTypeImports.probeFor(repo, uri);
     }
     return probes;
   }

--- a/tools/test/project_type_imports_test.dart
+++ b/tools/test/project_type_imports_test.dart
@@ -1,0 +1,316 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:tools/src/ast/source_index.dart';
+import 'package:tools/src/scaffold/type_imports.dart';
+import 'package:tools/src/workspace/frx_workspace.dart';
+
+/// What a generated file has to import to name a type this *project* declares —
+/// across every package `business` depends on, not just `models`.
+///
+/// The hole these cover: the resolver used to join `<root>/models/lib/<snake>.dart`
+/// and stop, so `add-field boot 'digest:MemoryDigest?'` wrote a field into
+/// `boot_state.dart` and a getter onto `selectors.dart` with nothing importing
+/// the type — two files that do not compile, and neither of them one a hand edit
+/// is allowed to fix.
+void main() {
+  late Directory root;
+
+  setUp(() => root = Directory.systemTemp.createTempSync('frx_imports_'));
+  tearDown(() => root.deleteSync(recursive: true));
+
+  void put(String relative, String content) {
+    File(p.join(root.path, relative))
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(content);
+  }
+
+  /// A `business` that declares [deps] as path dependencies.
+  void business(Map<String, String> deps) {
+    final entries = deps.entries
+        .map((e) => '  ${e.key}:\n    path: ${e.value}\n')
+        .join();
+    put('business/pubspec.yaml', 'name: business\n\ndependencies:\n$entries');
+    put('business/lib/redux/app_state.dart', '// app state\n');
+  }
+
+  List<String> importsFor(String type) => inSourceIndex(
+    () => ProjectTypeImports.forAll(FrxWorkspace(root), [type]),
+  );
+
+  group('a package with a barrel', () {
+    setUp(() {
+      business({'tm_memory': '../packages/tm_memory'});
+      put('packages/tm_memory/pubspec.yaml', 'name: tm_memory\n');
+      put('packages/tm_memory/lib/tm_memory.dart', '''
+export 'src/application/digest.dart';
+''');
+      put('packages/tm_memory/lib/src/application/digest.dart', '''
+class MemoryDigest {}
+''');
+    });
+
+    test('resolves through the entry point that exports the declaration', () {
+      expect(importsFor('MemoryDigest?'), ['package:tm_memory/tm_memory.dart']);
+    });
+
+    test('never names the private file that declares it', () {
+      // `package:tm_memory/src/application/digest.dart` is importable in the
+      // sense that pub will not stop you, and wrong in every other sense.
+      expect(importsFor('MemoryDigest'), isNot(contains(contains('/src/'))));
+    });
+
+    test('follows a chain of re-exports', () {
+      put('packages/tm_memory/lib/tm_memory.dart', "export 'src/all.dart';\n");
+      put('packages/tm_memory/lib/src/all.dart', "export 'application/digest.dart';\n");
+      expect(importsFor('MemoryDigest'), ['package:tm_memory/tm_memory.dart']);
+    });
+
+    test('a declaration nothing exports resolves to nothing', () {
+      // Reachable on disk, unreachable by import. Answering with the private
+      // path would be the one thing this module promises never to do.
+      put('packages/tm_memory/lib/src/application/secret.dart', 'class Hidden {}\n');
+      expect(importsFor('Hidden'), isEmpty);
+    });
+
+    test('a package that is not a dependency is not searched', () {
+      business({});
+      expect(importsFor('MemoryDigest'), isEmpty);
+    });
+
+    group('and a combinator on the export', () {
+      // `export 'src/sqlite_event_store.dart' show SqliteEventStore` is a real
+      // barrel in a real dependency here, and it declares two classes. Ignoring
+      // the combinator answers with an import that resolves and does not supply
+      // the name — the one failure this module promises it cannot have.
+      setUp(() {
+        put('packages/tm_memory/lib/src/application/digest.dart', '''
+class MemoryDigest {}
+class MemoryDigestInternals {}
+''');
+      });
+
+      test('show admits the name it lists', () {
+        put('packages/tm_memory/lib/tm_memory.dart',
+            "export 'src/application/digest.dart' show MemoryDigest;\n");
+        expect(importsFor('MemoryDigest'), [
+          'package:tm_memory/tm_memory.dart',
+        ]);
+      });
+
+      test('show excludes the sibling it does not', () {
+        put('packages/tm_memory/lib/tm_memory.dart',
+            "export 'src/application/digest.dart' show MemoryDigest;\n");
+        expect(importsFor('MemoryDigestInternals'), isEmpty);
+      });
+
+      test('hide excludes the name it lists', () {
+        put('packages/tm_memory/lib/tm_memory.dart',
+            "export 'src/application/digest.dart' hide MemoryDigest;\n");
+        expect(importsFor('MemoryDigest'), isEmpty);
+        expect(importsFor('MemoryDigestInternals'), [
+          'package:tm_memory/tm_memory.dart',
+        ]);
+      });
+
+      test('show of a union admits its cases', () {
+        // `ResultSuccess` is not a name a combinator can list — it is a
+        // constructor redirect on `Result`, and `show Result` carries it.
+        put('packages/tm_memory/lib/tm_memory.dart',
+            "export 'src/application/result.dart' show Result;\n");
+        put('packages/tm_memory/lib/src/application/result.dart', '''
+sealed class Result with _\$Result {
+  const factory Result.success() = ResultSuccess;
+}
+''');
+        expect(importsFor('ResultSuccess'), [
+          'package:tm_memory/tm_memory.dart',
+        ]);
+      });
+    });
+  });
+
+  group('models', () {
+    setUp(() {
+      business({'models': '../models'});
+      put('models/pubspec.yaml', 'name: models\n');
+    });
+
+    test('still resolves by file name, the convention add-model writes', () {
+      put('models/lib/task.dart', 'class Task {}\n');
+      expect(importsFor('IMap<int, Task>'), ['package:models/task.dart']);
+    });
+
+    test('resolves a union case through the redirect', () {
+      put('models/lib/result.dart', '''
+sealed class Result with _\$Result {
+  const factory Result.success() = ResultSuccess;
+}
+''');
+      expect(importsFor('ResultSuccess?'), ['package:models/result.dart']);
+    });
+
+    test('resolves a type in a subdirectory', () {
+      // The old walk was `recursive: false`, so `models/lib/converters/` was as
+      // invisible as another package was.
+      put('models/lib/converters/instant.dart', 'class InstantConverter {}\n');
+      expect(importsFor('InstantConverter'), [
+        'package:models/converters/instant.dart',
+      ]);
+    });
+
+    test('a name nothing declares resolves to nothing', () {
+      put('models/lib/task.dart', 'class Task {}\n');
+      expect(importsFor('String?'), isEmpty);
+      expect(importsFor('TaskList'), isEmpty);
+    });
+
+    test('a file named after the type but not declaring it is not it', () {
+      // The lookup used to answer from the file *name* — `Task` is in
+      // `task.dart` — without ever opening it. A repository where that
+      // convention does not hold got `package:models/task.dart` for `Task`: an
+      // import that resolves and does not supply the name, which is the one
+      // failure this module says it cannot have.
+      put('models/lib/task.dart', 'class TaskList {}\n');
+      put('models/lib/other.dart', 'class Task {}\n');
+      expect(importsFor('Task'), ['package:models/other.dart']);
+      expect(importsFor('TaskList'), ['package:models/task.dart']);
+    });
+  });
+
+  group('every declaration form Dart has', () {
+    // The pre-filter that keeps the widened search affordable is a *second*
+    // reading of "what is a declaration", written in regex against the text
+    // while `_declares` reads the tree. A form the tree accepts and the text
+    // rejects is silent: the file is never parsed, so the declaration is never
+    // seen and the import is never written. This is the assertion that the
+    // cheap reading stays no narrower than the authoritative one.
+    const forms = {
+      'class': 'class Shape {}',
+      'abstract class': 'abstract class Shape {}',
+      'abstract final class': 'abstract final class Shape {}',
+      'sealed class': 'sealed class Shape {}',
+      'base class': 'base class Shape {}',
+      'interface class': 'interface class Shape {}',
+      'mixin class': 'mixin class Shape {}',
+      'generic class': 'class Shape<T extends num> {}',
+      'enum': 'enum Shape { a, b }',
+      'mixin': 'mixin Shape {}',
+      'extension type': 'extension type Shape(int i) {}',
+      'extension type const': 'extension type const Shape(int i) {}',
+      'typedef': 'typedef Shape = void Function();',
+      'legacy typedef': 'typedef void Shape(int a);',
+    };
+
+    forms.forEach((label, source) {
+      test('$label is found', () {
+        business({'models': '../models'});
+        put('models/pubspec.yaml', 'name: models\n');
+        put('models/lib/shape.dart', '$source\n');
+        expect(
+          importsFor('Shape?'),
+          ['package:models/shape.dart'],
+          reason: source,
+        );
+      });
+    });
+
+    test('a union case is found through its redirect', () {
+      business({'models': '../models'});
+      put('models/pubspec.yaml', 'name: models\n');
+      put('models/lib/shape.dart', '''
+sealed class Shape with _\$Shape {
+  const factory Shape.round() = ShapeRound;
+}
+''');
+      expect(importsFor('ShapeRound'), ['package:models/shape.dart']);
+    });
+  });
+
+  group('two packages declaring one name', () {
+    setUp(() {
+      business({'models': '../models', 'tm_core': '../packages/tm_core'});
+      put('models/pubspec.yaml', 'name: models\n');
+      put('models/lib/clock.dart', 'class Clock {}\n');
+      put('packages/tm_core/pubspec.yaml', 'name: tm_core\n');
+      put('packages/tm_core/lib/tm_core.dart', "export 'src/clock.dart';\n");
+      put('packages/tm_core/lib/src/clock.dart', 'class Clock {}\n');
+    });
+
+    test('resolve to nothing rather than to a guess', () {
+      // A missed import is a compile error naming the type. A wrong one binds
+      // silently to the other package's class. Only the first is recoverable by
+      // reading the error, so ambiguity is answered as "I do not know".
+      expect(importsFor('Clock'), isEmpty);
+    });
+  });
+
+  group('the prune probe', () {
+    setUp(() {
+      business({'tm_memory': '../packages/tm_memory'});
+      put('packages/tm_memory/pubspec.yaml', 'name: tm_memory\n');
+      put('packages/tm_memory/lib/tm_memory.dart', '''
+export 'src/digest.dart';
+export 'src/record.dart';
+''');
+      put('packages/tm_memory/lib/src/digest.dart', 'class MemoryDigest {}\n');
+      put('packages/tm_memory/lib/src/record.dart', 'class MemoryRecord {}\n');
+    });
+
+    test('keeps the import while any name it supplies survives', () {
+      final probe = inSourceIndex(
+        () => ProjectTypeImports.probeFor(
+          FrxWorkspace(root),
+          'package:tm_memory/tm_memory.dart',
+        ),
+      );
+      // Both names come through one entry point, so the sibling keeps it alive.
+      expect(probe('final MemoryRecord? last;'), isTrue);
+      expect(probe('final String? last;'), isFalse);
+    });
+  });
+
+  group('cost', () {
+    // The widened search space is the whole dependency closure, and the thing
+    // that keeps it affordable is that a miss never parses. Asserted rather
+    // than measured once by hand: a pre-filter that quietly stops filtering is
+    // invisible until somebody times `add-field`.
+    setUp(() {
+      business({'tm_core': '../packages/tm_core'});
+      put('packages/tm_core/pubspec.yaml', 'name: tm_core\n');
+      put('packages/tm_core/lib/tm_core.dart', "export 'src/task.dart';\n");
+      for (var i = 0; i < 40; i++) {
+        put('packages/tm_core/lib/src/file_$i.dart', '''
+/// Mentions String, Task and Object the way any file does.
+class Thing$i {
+  final String? name = null;
+  final Object? task = null;
+}
+''');
+      }
+      put('packages/tm_core/lib/src/task.dart', 'class Task {}\n');
+    });
+
+    test('a miss parses nothing', () {
+      final index = SourceIndex();
+      final imports = withSourceIndex(
+        index,
+        () => ProjectTypeImports.forAll(FrxWorkspace(root), ['String?']),
+      );
+      expect(imports, isEmpty);
+      expect(index.parses, 0);
+    });
+
+    test('a hit parses only what it had to', () {
+      final index = SourceIndex();
+      final imports = withSourceIndex(
+        index,
+        () => ProjectTypeImports.forAll(FrxWorkspace(root), ['Task?']),
+      );
+      expect(imports, ['package:tm_core/tm_core.dart']);
+      // The declaring file, plus the barrel found walking up to it.
+      expect(index.parses, lessThan(4));
+    });
+  });
+}


### PR DESCRIPTION
`add-field boot 'digest:MemoryDigest?'` wrote the field into the state and the getter onto the facade with nothing importing the type — two files that do not compile, and neither one a hand edit is allowed to fix. The gap was not that domain types were unknown, which is how it reads from outside; `models`-resident ones resolved fine. It was that the search space was one directory: `<root>/models/lib/*.dart`, walked non-recursively. A sibling package brought in by a path dependency was as invisible as `models/lib/converters/` was.

The set of packages now comes from `business/pubspec.yaml`, and from its `path:` dependencies rather than the workspace list — those are different sets, and only one of them is what a generated file may import. Direct only: Dart lets a file import what its own package declares, so a transitive walk would produce imports that do not compile.

Resolution goes to the declaration and then up the export graph to the entry point that carries it, honouring `show`/`hide`. A file under `lib/src/` is never the answer.

Dropped along the way: the by-file-name tier, which answered `Task` is in `task.dart` from one `existsSync` and never opened the file. A `task.dart` holding `TaskList`, with `Task` next door, made it emit an import that resolves and does not supply the name — the one failure this module's doc promises away. The convention it encoded survives, now checked.

Two names that resolve in two packages resolve to neither. A miss is a compile error naming the type; a wrong import binds silently to somebody else's class.

Cost, on a real app with six path dependencies (228 files, 1.3 MB): a miss parses nothing, a hit parses under four files, one `add-field` is ~300 ms. That rests on a text pre-filter matching the *declaration* rather than the identifier — `contains('String')` hits nearly every file, and the first version spent 161 parses to answer "no". The filter is a second reading of what a declaration is, so a test holds it no narrower than the tree walk over every form Dart has.